### PR TITLE
feat([sc-17978]): add support for SHIPYARD_DOMAIN* environment variables

### DIFF
--- a/src/scripts/orb.py
+++ b/src/scripts/orb.py
@@ -175,7 +175,7 @@ def main():
 
 
     additional_urls = environment_data.get("additional_urls", {})
-    shipyard_additional_urls_vars = [f'export SHIPYARD_DOMAIN_{k.upper()}={v}' for (k,v) in additional_urls.items()]
+    shipyard_additional_urls_vars = [f'export SHIPYARD_DOMAIN_{k.upper().replace("-","_")}={v}' for (k,v) in additional_urls.items()]
 
     # Write the data to the job's environment
     with open(bash_env_path, 'a') as bash_env:

--- a/src/scripts/orb.py
+++ b/src/scripts/orb.py
@@ -185,6 +185,7 @@ def main():
             'export SHIPYARD_ENVIRONMENT_ID={}'.format(environment_id),
             'export SHIPYARD_ENVIRONMENT_READY={}'.format(environment_data["ready"]),
             'export SHIPYARD_ENVIRONMENT_RETIRED={}'.format(environment_data["retired"]),
+            'export SHIPYARD_DOMAIN={}'.format(environment_data["url"]),
         ] + (['export SHIPYARD_ENVIRONMENT_COMMIT_HASH={}'.format(commit_hash)] if commit_hash else [])
         + shipyard_additional_urls_vars
         ))

--- a/src/scripts/orb.py
+++ b/src/scripts/orb.py
@@ -173,6 +173,10 @@ def main():
         print('WARNING: unable to retrieve commit hash')
         commit_hash = None
 
+
+    additional_urls = environment_data.get("additional_urls", {})
+    shipyard_additional_urls_vars = [{ f'SHIPYARD_DOMAIN_{e.service_name.upper()}': e.domain } for e in additional_urls]
+
     # Write the data to the job's environment
     with open(bash_env_path, 'a') as bash_env:
         bash_env.write('\n'.join([
@@ -182,6 +186,7 @@ def main():
             'export SHIPYARD_ENVIRONMENT_READY={}'.format(environment_data["ready"]),
             'export SHIPYARD_ENVIRONMENT_RETIRED={}'.format(environment_data["retired"]),
         ] + (['export SHIPYARD_ENVIRONMENT_COMMIT_HASH={}'.format(commit_hash)] if commit_hash else [])
+        + shipyard_additional_urls_vars
         ))
 
     print(f'Shipyard environment {environment_id} data written to {bash_env_path}!')

--- a/src/scripts/orb.py
+++ b/src/scripts/orb.py
@@ -175,7 +175,7 @@ def main():
 
 
     additional_urls = environment_data.get("additional_urls", {})
-    shipyard_additional_urls_vars = [{ f'SHIPYARD_DOMAIN_{e.service_name.upper()}': e.domain } for e in additional_urls]
+    shipyard_additional_urls_vars = [f'export SHIPYARD_DOMAIN_{k.upper()}={v}' for (k,v) in additional_urls.items()]
 
     # Write the data to the job's environment
     with open(bash_env_path, 'a') as bash_env:

--- a/src/scripts/orb.sh
+++ b/src/scripts/orb.sh
@@ -56,10 +56,10 @@ fi
 
 # Download the orb
 cd /tmp || exit
-wget -q https://github.com/shipyardbuild/circleci-orb/archive/refs/heads/$CIRCLE_BRANCH.tar.gz -O code.tar.gz
+wget -q https://github.com/shipyardbuild/circleci-orb/archive/refs/heads/"$CIRCLE_BRANCH".tar.gz -O code.tar.gz
 tar xvzf code.tar.gz > /dev/null
 
-cd /tmp/circleci-orb-$CIRCLE_BRANCH/src/scripts || exit
+cd /tmp/circleci-orb-"$CIRCLE_BRANCH"/src/scripts || exit
 
 # Run the orb
 pip install -r requirements.txt > /dev/null

--- a/src/scripts/orb.sh
+++ b/src/scripts/orb.sh
@@ -56,10 +56,10 @@ fi
 
 # Download the orb
 cd /tmp || exit
-wget -q https://github.com/shipyardbuild/circleci-orb/archive/refs/heads/"$CIRCLE_BRANCH".tar.gz -O code.tar.gz
-tar xvzf code.tar.gz > /dev/null
+wget -q wget -q https://github.com/shipyardbuild/circleci-orb/archive/refs/heads/feat/ci-integration-host-injection.tar.gz
+tar xvzf ci-integration-host-injection.tar.gz > /dev/null
 
-cd /tmp/circleci-orb-"$CIRCLE_BRANCH"/src/scripts || exit
+cd /tmp/circleci-orb-feat-ci-integration-host-injection/src/scripts || exit
 
 # Run the orb
 pip install -r requirements.txt > /dev/null

--- a/src/scripts/orb.sh
+++ b/src/scripts/orb.sh
@@ -56,10 +56,10 @@ fi
 
 # Download the orb
 cd /tmp || exit
-wget -q https://github.com/shipyardbuild/circleci-orb/archive/refs/heads/feat/ci-integration-host-injection.tar.gz
-tar xvzf ci-integration-host-injection.tar.gz > /dev/null
+wget -q https://github.com/shipyardbuild/circleci-orb/archive/refs/heads/master.tar.gz
+tar xvzf master.tar.gz > /dev/null
 
-cd /tmp/circleci-orb-feat-ci-integration-host-injection/src/scripts || exit
+cd /tmp/circleci-orb-master/src/scripts || exit
 
 # Run the orb
 pip install -r requirements.txt > /dev/null

--- a/src/scripts/orb.sh
+++ b/src/scripts/orb.sh
@@ -56,10 +56,10 @@ fi
 
 # Download the orb
 cd /tmp || exit
-wget -q https://github.com/shipyardbuild/circleci-orb/archive/refs/heads/master.tar.gz
-tar xvzf master.tar.gz > /dev/null
+wget -q https://github.com/shipyardbuild/circleci-orb/archive/refs/heads/$CIRCLE_BRANCH.tar.gz -O code.tar.gz
+tar xvzf code.tar.gz > /dev/null
 
-cd /tmp/circleci-orb-master/src/scripts || exit
+cd /tmp/circleci-orb-$CIRCLE_BRANCH/src/scripts || exit
 
 # Run the orb
 pip install -r requirements.txt > /dev/null

--- a/src/scripts/orb.sh
+++ b/src/scripts/orb.sh
@@ -56,7 +56,7 @@ fi
 
 # Download the orb
 cd /tmp || exit
-wget -q wget -q https://github.com/shipyardbuild/circleci-orb/archive/refs/heads/feat/ci-integration-host-injection.tar.gz
+wget -q https://github.com/shipyardbuild/circleci-orb/archive/refs/heads/feat/ci-integration-host-injection.tar.gz
 tar xvzf ci-integration-host-injection.tar.gz > /dev/null
 
 cd /tmp/circleci-orb-feat-ci-integration-host-injection/src/scripts || exit


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

Updates orb to fetch additional service domains from environments API. Additionally, exports `SHIPYARD_DOMAIN` as duplicate of `SHIPYARD_ENVIRONMENT_URL` as that's what we use elsewhere in our app.

## Motivation:

Customer request based on recent feature.

## Checklist:
- [ ] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.
